### PR TITLE
documentations/pushpayload-classification

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -232,7 +232,7 @@ a single object) and performs the following actions:</p>
 <li>Updates any relevant request hashes using <code>_pushToRequestHashes</code>.</li>
 </ol>
 </dd>
-<dt><a href="#pushPayload">pushPayload(collectionName, collectionRecords)</a> ⇒ <code>Array</code> | <code>Object</code> ℗</dt>
+<dt><a href="#pushPayload">pushPayload(collectionName, collectionRecords)</a> ⇒ <code>Array</code> | <code>Object</code></dt>
 <dd><p>Pushes records to a collection, aliases, and request hashes.</p>
 <p>This method orchestrates the process of adding or updating records
 in various data stores within the <code>ApiResourceManager</code>. It takes a
@@ -1002,7 +1002,7 @@ a single object) and performs the following actions:
 
 <a name="pushPayload"></a>
 
-## pushPayload(collectionName, collectionRecords) ⇒ <code>Array</code> \| <code>Object</code> ℗
+## pushPayload(collectionName, collectionRecords) ⇒ <code>Array</code> \| <code>Object</code>
 Pushes records to a collection, aliases, and request hashes.
 
 This method orchestrates the process of adding or updating records
@@ -1017,7 +1017,6 @@ a single object) and performs the following actions:
 
 **Kind**: global function  
 **Returns**: <code>Array</code> \| <code>Object</code> - The updated collection records.  
-**Access**: private  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/packages/dist/arm-js-library.js
+++ b/packages/dist/arm-js-library.js
@@ -894,7 +894,6 @@ Fix: Try adding ${collectionName} on your ARM config initialization.`;
    * 3. Updates any relevant aliases using `_pushToAliases`.
    * 4. Updates any relevant request hashes using `_pushToRequestHashes`.
    *
-   * @private
    * @param {string} collectionName - The name of the collection.
    * @param {Array|Object} collectionRecords - The records to be pushed.
    * @returns {Array|Object} The updated collection records.

--- a/packages/src/lib/api-resource-manager.js
+++ b/packages/src/lib/api-resource-manager.js
@@ -1090,7 +1090,6 @@ export default class ApiResourceManager {
    * 3. Updates any relevant aliases using `_pushToAliases`.
    * 4. Updates any relevant request hashes using `_pushToRequestHashes`.
    *
-   * @private
    * @param {string} collectionName - The name of the collection.
    * @param {Array|Object} collectionRecords - The records to be pushed.
    * @returns {Array|Object} The updated collection records.

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -410,12 +410,11 @@ declare module "arm-js-library" {
          * 3. Updates any relevant aliases using `_pushToAliases`.
          * 4. Updates any relevant request hashes using `_pushToRequestHashes`.
          *
-         * @private
          * @param {string} collectionName - The name of the collection.
          * @param {Array|Object} collectionRecords - The records to be pushed.
          * @returns {Array|Object} The updated collection records.
          */
-        private pushPayload;
+        pushPayload(collectionName: string, collectionRecords: any[] | any): any[] | any;
         /**
          * Pushes a request and its corresponding response to the request hash store.
          *


### PR DESCRIPTION
Removal of `@private` tagging for pushPayload function to eliminate vscode warning.