### PR TITLE
features/support-string-collection-record-id

### DIFF
--- a/packages/dist/arm-js-library.js
+++ b/packages/dist/arm-js-library.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 import _ from "lodash";
 import * as mobx from "mobx";
-import { v1, NIL } from "uuid";
+import { v1, validate, NIL } from "uuid";
 import md5 from "md5";
 import qs from "qs";
 /**
@@ -540,7 +540,10 @@ Fix: Try adding ${collectionName} on your ARM config initialization.`;
       }
     );
     const collectionRecordId = getProperty(collectionRecord, "id");
-    const isCollectionRecordIdValid = isNumber(collectionRecordId);
+    const isCollectionRecordIdValid = isEqual(
+      validate(collectionRecordId),
+      false
+    );
     return this._request({
       resourceMethod: isCollectionRecordIdValid ? "put" : "post",
       resourceName: collectionName,

--- a/packages/src/lib/api-resource-manager.js
+++ b/packages/src/lib/api-resource-manager.js
@@ -29,7 +29,7 @@
 import axios from 'axios'
 import _ from 'lodash'
 import * as mobx from 'mobx'
-import { v1 as uuidv1, NIL as NIL_UUID } from 'uuid'
+import { v1 as uuidv1, validate as uuidValidate, NIL as NIL_UUID } from 'uuid'
 import md5 from 'md5'
 import qs from 'qs'
 
@@ -681,7 +681,10 @@ export default class ApiResourceManager {
       },
     )
     const collectionRecordId = getProperty(collectionRecord, 'id')
-    const isCollectionRecordIdValid = isNumber(collectionRecordId)
+    const isCollectionRecordIdValid = isEqual(
+      uuidValidate(collectionRecordId),
+      false,
+    )
 
     return this._request({
       resourceMethod: isCollectionRecordIdValid ? 'put' : 'post',
@@ -2019,6 +2022,7 @@ export default class ApiResourceManager {
    *                          configuration in `config`.
    */
   findRecord(resource, id, params = {}, config = {}) {
+    console.log('findRecord', resource, id, params, config)
     const requestObject = {
       resourceMethod: 'get',
       resourceName: resource,

--- a/packages/src/lib/api-resource-manager.js
+++ b/packages/src/lib/api-resource-manager.js
@@ -2022,7 +2022,6 @@ export default class ApiResourceManager {
    *                          configuration in `config`.
    */
   findRecord(resource, id, params = {}, config = {}) {
-    console.log('findRecord', resource, id, params, config)
     const requestObject = {
       resourceMethod: 'get',
       resourceName: resource,


### PR DESCRIPTION
# Description

Support collection record id as type string.

## Changes

- Added uuid validation on collection record save function to support id as type string besides id integer.

## Screenshots/Images

<img width="1944" height="1242" alt="image" src="https://github.com/user-attachments/assets/0b8cd424-9658-4acf-b0cf-a26246ee1bd9" />
<img width="1474" height="500" alt="image" src="https://github.com/user-attachments/assets/92c847b1-0dd1-4ec6-a99b-38f43a038f2e" />
<img width="2412" height="356" alt="image" src="https://github.com/user-attachments/assets/beb3dc11-b4e4-4bdc-a004-3719a2961e73" />

## How Has This Been Tested?

- Locally and unit tested

## Checklist

- Passed build
- Passed unit test

## Reviewer Guidance

- N/A
