### PR TITLE
docs(contributing): add CONTRIBUTING.md and link from README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,155 @@
+# Contributing to ARM JS Library
+
+Thank you for your interest in contributing! Please read through this guide before submitting any contributions.
+
+---
+
+## Table of Contents
+
+- [Getting Started](#getting-started)
+- [Branch Naming Convention](#branch-naming-convention)
+- [Commit Message Convention](#commit-message-convention)
+- [Development Workflow](#development-workflow)
+- [Testing](#testing)
+- [Pull Request Process](#pull-request-process)
+- [Code Standards](#code-standards)
+
+---
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js >= 20.0.0
+- Yarn 1.22.22
+
+### Setup
+
+```bash
+# Clone the repository
+git clone https://github.com/michaeljymsgutierrez/arm-js-library.git
+cd arm-js-library
+
+# Install dependencies
+cd packages
+yarn install
+
+# Run tests to verify setup
+yarn test
+
+# Build the library
+yarn build
+```
+
+---
+
+## Branch Naming Convention
+
+Branches must follow this format:
+
+```
+type/short-description
+```
+
+| Type        | When to use                               |
+| ----------- | ----------------------------------------- |
+| `feat/`     | New feature                               |
+| `fix/`      | Bug fix                                   |
+| `chore/`    | Maintenance tasks (deps, config, cleanup) |
+| `docs/`     | Documentation only changes                |
+| `refactor/` | Code restructuring, no behavior change    |
+| `test/`     | Adding or updating tests                  |
+| `hotfix/`   | Urgent fix for production issues          |
+| `release/`  | Release preparation                       |
+
+**Examples:**
+
+- `feat/record-pagination`
+- `fix/alias-not-updating`
+- `chore/packages-dependency-updates`
+- `docs/add-contributing-guide`
+- `refactor/collection-manager`
+- `test/query-record-coverage`
+- `hotfix/save-method-crash`
+- `release/v2.10.0`
+
+---
+
+## Commit Message Convention
+
+This project follows the [Conventional Commits](https://www.conventionalcommits.org) specification.
+
+```
+type(scope): description
+```
+
+| Type       | When to use                            |
+| ---------- | -------------------------------------- |
+| `feat`     | New feature                            |
+| `fix`      | Bug fix                                |
+| `chore`    | Maintenance, no production code change |
+| `docs`     | Documentation only                     |
+| `refactor` | Code restructuring, no behavior change |
+| `test`     | Adding or updating tests               |
+| `style`    | Formatting, whitespace                 |
+| `perf`     | Performance improvement                |
+| `ci`       | CI/CD changes                          |
+| `build`    | Build system or dependency changes     |
+
+**Examples:**
+
+- `feat(records): add pagination support`
+- `fix(alias): resolve alias not updating on reload`
+- `chore(deps): upgrade axios from 1.13.5 to 1.18.1`
+- `docs(contributing): add CONTRIBUTING.md`
+- `test(query): add coverage for queryRecord edge cases`
+
+---
+
+## Development Workflow
+
+1. Fork the repository
+2. Create a branch following the [Branch Naming Convention](#branch-naming-convention)
+3. Make your changes in `packages/src/lib/api-resource-manager.js`
+4. Write or update tests in `packages/tests/`
+5. Run the test suite and ensure all tests pass
+6. Submit a pull request pointing to `develop`
+
+---
+
+## Testing
+
+All changes must pass the full test suite before submitting a PR.
+
+```bash
+cd packages
+
+# Run tests once
+yarn test
+
+# Run tests in watch mode
+yarn test:watch
+```
+
+- Write tests for any new functionality
+- Ensure existing tests are not broken
+- Tests live in `packages/tests/units/` organized by feature domain
+
+---
+
+## Pull Request Process
+
+- Target branch: `develop`
+- Use the existing PR template (`.github/PULL_REQUEST_TEMPLATE.md`)
+- Link any related GitHub issues
+- Assign the appropriate reviewers
+- Ensure CI checks pass before requesting review
+
+---
+
+## Code Standards
+
+- Follow the existing code patterns in `packages/src/lib/api-resource-manager.js`
+- Run ESLint before submitting: `yarn build` (ESLint runs as part of the build)
+- Do not leave `console.log` statements in production code
+- Keep changes focused - one concern per PR

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ Thank you for your interest in contributing! Please read through this guide befo
 - [Development Workflow](#development-workflow)
 - [Testing](#testing)
 - [Pull Request Process](#pull-request-process)
+- [Labels](#labels)
 - [Code Standards](#code-standards)
 
 ---
@@ -144,6 +145,26 @@ yarn test:watch
 - Link any related GitHub issues
 - Assign the appropriate reviewers
 - Ensure CI checks pass before requesting review
+
+---
+
+## Labels
+
+Apply the appropriate label(s) when creating a PR or issue:
+
+| Label | When to use |
+|---|---|
+| `feat` | New feature additions |
+| `fix` | Bug fixes and patches |
+| `chore` | Maintenance tasks, configs, and cleanups |
+| `docs` | Documentation additions or improvements |
+| `refactor` | Code restructuring with no behavior change |
+| `deps` | Dependency updates and version bumps |
+| `release` | Release preparation and versioning |
+| `bug` | Confirmed bugs and reported issues |
+| `experimental` | Experimental or exploratory changes |
+| `javascript` | JavaScript code changes |
+| `hacktoberfest-accepted` | Accepted Hacktoberfest contributions |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@
   - [Data Validation and Comparison](#data-validation-and-comparison)
 - [Credits](#credits)
 - [License](#license)
+- [Contributing](#contributing)
 
 ## Overview
 
@@ -1071,3 +1072,7 @@ const addresses = [
 ## License
 
 This project is licensed under the [MIT](https://github.com/michaeljymsgutierrez/arm-js-library/blob/main/LICENSE.md) License.
+
+## Contributing
+
+Contributions are welcome! Please read the [CONTRIBUTING.md](./CONTRIBUTING.md) guide before submitting any changes.


### PR DESCRIPTION
# Description

Adds a `CONTRIBUTING.md` guide to the repository root and links it from `README.md`. This gives contributors a clear reference for dev setup, branch naming, commit message conventions, testing requirements, and the PR process.

Github Issue: N/A

## Changes

- `CONTRIBUTING.md` - new contributor guide covering dev setup, branch naming convention, commit message convention, development workflow, testing, PR process, and code standards
- `README.md` - added `Contributing` entry to Table of Contents and a `## Contributing` section at the bottom linking to `CONTRIBUTING.md`

## Screenshots/Images

N/A

## How Has This Been Tested?

- Manual testing: Reviewed the rendered markdown for correctness and verified all links are valid.

## Checklist

- [x] Code follows the project's coding standards and best practices.
- [x] Existing tests pass.
- [x] Documentation is updated to reflect changes.
- [x] The PR is assigned to the correct reviewers.

## Reviewer Guidance

- Open `CONTRIBUTING.md` and verify all sections are accurate and complete
- Open `README.md` and verify the `Contributing` link in the Table of Contents and the `## Contributing` section at the bottom both resolve correctly
