### PR TITLE
fix(record): remove Number() coercion in reload and destroyRecord to support string ids

### DIFF
--- a/packages/dist/arm-js-library.js
+++ b/packages/dist/arm-js-library.js
@@ -572,7 +572,7 @@ Fix: Try adding ${collectionName} on your ARM config initialization.`;
     return this._request({
       resourceMethod: "delete",
       resourceName: getProperty(currentRecord, "collectionName"),
-      resourceId: Number(getProperty(currentRecord, "id")),
+      resourceId: getProperty(currentRecord, "id"),
       resourceParams: {},
       resourcePayload: null,
       resourceFallback: {},
@@ -593,7 +593,7 @@ Fix: Try adding ${collectionName} on your ARM config initialization.`;
     return this._request({
       resourceMethod: "get",
       resourceName: getProperty(currentRecord, "collectionName"),
-      resourceId: Number(getProperty(currentRecord, "id")),
+      resourceId: getProperty(currentRecord, "id"),
       resourceParams: {},
       resourcePayload: null,
       resourceFallback: {},

--- a/packages/src/lib/api-resource-manager.js
+++ b/packages/src/lib/api-resource-manager.js
@@ -715,7 +715,7 @@ export default class ApiResourceManager {
     return this._request({
       resourceMethod: 'delete',
       resourceName: getProperty(currentRecord, 'collectionName'),
-      resourceId: Number(getProperty(currentRecord, 'id')),
+      resourceId: getProperty(currentRecord, 'id'),
       resourceParams: {},
       resourcePayload: null,
       resourceFallback: {},
@@ -737,7 +737,7 @@ export default class ApiResourceManager {
     return this._request({
       resourceMethod: 'get',
       resourceName: getProperty(currentRecord, 'collectionName'),
-      resourceId: Number(getProperty(currentRecord, 'id')),
+      resourceId: getProperty(currentRecord, 'id'),
       resourceParams: {},
       resourcePayload: null,
       resourceFallback: {},

--- a/packages/tests/mirage/index.js
+++ b/packages/tests/mirage/index.js
@@ -46,8 +46,11 @@ export default function () {
           : request.requestBody
       })
 
-      this.delete('/addresses/:id', () => {
-        return { data: addresses.data[1] }
+      this.delete('/addresses/:id', (schema, request) => {
+        const { id } = request.params
+        return isNaN(Number(id))
+          ? { data: { id, type: 'addresses', attributes: {} } }
+          : { data: addresses.data[1] }
       })
     },
   })

--- a/packages/tests/units/record.js
+++ b/packages/tests/units/record.js
@@ -158,6 +158,22 @@ const execRecordTest = (ARM) => {
         expect(record.get('attributes.address1')).toBe('Anabu Hills Test 4')
       })
 
+      test('Verify reload with string collection record id', async () => {
+        ARM.pushPayload('addresses', [
+          {
+            id: 'JO-26181S4VPU65',
+            type: 'addresses',
+            attributes: { address1: 'String ID Address', kind: 'office' },
+          },
+        ])
+        const record = ARM.peekRecord('addresses', 'JO-26181S4VPU65')
+        expect(record).toBeDefined()
+
+        const result = await record.reload()
+        expect(result).toBeDefined()
+        expect(record.get('isError')).toBe(false)
+      })
+
       test('Verify rollbackAttributes functionality', async () => {
         await ARM.findRecord('addresses', 2518368, null, {
           autoResolve: false,
@@ -202,6 +218,22 @@ const execRecordTest = (ARM) => {
 
         expect(result).toBeDefined()
         expect(ARM.peekRecord('addresses', 2518368)).toBeUndefined()
+      })
+
+      test('Verify destroyRecord with string collection record id', async () => {
+        ARM.pushPayload('addresses', [
+          {
+            id: 'JO-26181S4VPU65',
+            type: 'addresses',
+            attributes: { address1: 'String ID Address', kind: 'office' },
+          },
+        ])
+        const record = ARM.peekRecord('addresses', 'JO-26181S4VPU65')
+        expect(record).toBeDefined()
+
+        const result = await record.destroyRecord()
+        expect(result).toBeDefined()
+        expect(ARM.peekRecord('addresses', 'JO-26181S4VPU65')).toBeUndefined()
       })
 
       test('Verify getCollection functionality', async () => {


### PR DESCRIPTION
# Description

`record.reload()` and `record.destroyRecord()` were calling `Number()` on the record ID before passing it to the internal `_request()` method. For numeric IDs this was harmless, but for string IDs like `JO-26181S4VPU65`, `Number()` returns `NaN`, causing the request URL to become `/api/v1/resource/NaN` instead of `/api/v1/resource/JO-26181S4VPU65`.

This fix removes the `Number()` coercion from both `_reloadRecord` and `_deleteRecord`, passing the ID as-is - consistent with how `_saveRecord` and `findRecord` already handle IDs. The internal `_request()` method already supports both number and string IDs via `isNumber(resourceId) || isString(resourceId)`.

Github Issue: N/A

## Changes

- `packages/src/lib/api-resource-manager.js` - removed `Number()` coercion from `_reloadRecord` (line 740) and `_deleteRecord` (line 718); both now pass `getProperty(currentRecord, 'id')` directly as `resourceId`
- `packages/tests/units/record.js` - added two new tests: "Verify reload with string collection record id" and "Verify destroyRecord with string collection record id"
- `packages/tests/mirage/index.js` - updated `DELETE /addresses/:id` handler to echo back a record with the matching string ID when a non-numeric ID is provided, enabling proper unload assertion in the destroyRecord test
- `packages/dist/arm-js-library.js` - rebuilt distribution file reflecting the source fix

## Screenshots/Images

N/A - no UI changes.

## How Has This Been Tested?

- **Unit tests:** 2 new tests added covering `reload` and `destroyRecord` with string IDs - both pass
- **Full suite:** All 83 tests pass (`yarn test`)
- **Coverage verified:** Audited all ID-handling paths in the library - no other `Number()` or `parseInt` coercions remain; `_saveRecord`, `findRecord`, `peekRecord`, and `_getCollectionRecord` all already handle string IDs correctly

## Checklist

- [x] Code follows the project's coding standards and best practices.
- [x] Tests are written for new functionality and existing tests pass.
- [x] Documentation is updated to reflect changes.
- [x] The PR is assigned to the correct reviewers.

## Reviewer Guidance

- The fix is minimal - only 2 lines changed in `api-resource-manager.js` (the `Number()` wrappers in `_reloadRecord` and `_deleteRecord`)
- `_saveRecord` was already correct and did not need changes - it uses `uuidValidate()` to distinguish new records (UUID) from existing ones (any non-UUID ID), then passes the ID as-is
- The Mirage DELETE handler update is test-only - it now returns the correct record shape when a non-numeric ID is used, so `unloadRecord` can find and remove the right record by hashId
